### PR TITLE
Always use `openseespy` fiber section API in `solver.py`

### DIFF
--- a/src/osmg/solver.py
+++ b/src/osmg/solver.py
@@ -441,9 +441,8 @@ class Analysis:
             sec = elm.section
             parts = sec.section_parts.values()
             if sec.uid not in defined_sections:
-                if ops.__name__ == 'openseespy.opensees':
-                    ops.section(*sec.ops_args())
-                    defined_sections[sec.uid] = sec
+                ops.section(*sec.ops_args())
+                defined_sections[sec.uid] = sec
                 fibers = []
                 for part in parts:
                     mat = part.ops_material
@@ -453,29 +452,10 @@ class Analysis:
                         area = piece.area
                         z_loc = piece.centroid.x
                         y_loc = piece.centroid.y
-                        if ops.__name__ == 'openseespy.opensees':
-                            ops.fiber(
-                                y_loc, z_loc, area, part.ops_material.uid
-                            )
-                        else:  # ops.__name__ == 'opensees.openseespy'
-                            fibers.append(
-                                [y_loc, z_loc, area, part.ops_material.uid]
-                            )
+                        ops.fiber(
+                            y_loc, z_loc, area, part.ops_material.uid
+                        )
 
-                if ops.__name__ == 'opensees.openseespy':
-                    fiber_commands = ';\n     '.join(
-                        "fiber " + " ".join(map(str, fiber))
-                        for fiber in fibers
-                    )
-                    cmd = textwrap.dedent(
-                        f"""
-                    section {' '.join(map(str,sec.ops_args()))} {{
-                      {fiber_commands}
-                    }}
-                    """
-                    )
-                    ops.eval(cmd)
-                    defined_sections[sec.uid] = sec
 
             ops.beamIntegration(*elm.integration.ops_args())
             ops.geomTransf(*elm.geomtransf.ops_args())

--- a/src/osmg/solver.py
+++ b/src/osmg/solver.py
@@ -33,7 +33,6 @@ from time import perf_counter
 import os
 import pickle
 import logging
-import textwrap
 from tqdm import tqdm
 import numpy as np
 import numpy.typing as npt


### PR DESCRIPTION
The classic fiber section API is now available in `opensees>=0.0.58`! This means we can do away with a lot of the branching in `solver.py`. Now I'll try to fix the time series stuff.